### PR TITLE
Missing rich requirement in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     requests >=2.24
     tomli>=1.2.3; python_version<'3.11'
     urllib3
+    rich >= 12.5.1
 
 # typing_extensions are included for RHEL 8.5
 # typing_extensions;python_version<'3.8'


### PR DESCRIPTION
This PR adds the `rich >= 12.5.1` install requirement to setup.cfg.